### PR TITLE
5 create base file traverser

### DIFF
--- a/file_workers/base_file_traverser.py
+++ b/file_workers/base_file_traverser.py
@@ -1,0 +1,53 @@
+import os
+from typing import Any
+
+from file_workers.file_action import FileAction
+
+
+class BaseFileTraverser:
+
+    """
+    Base class for traversing local files
+
+    """
+
+    def __init__(self, abs_path_to_dir: str, file_action: FileAction):
+
+        """
+
+        :param abs_path_to_dir: str, (valid) abs path to the desired local directory for traversal
+        :param file_action: concrete child of FileActions with the desired functionality implemented
+        """
+
+        self._abs_path_to_dir: str = abs_path_to_dir
+        self._file_action: FileAction = file_action
+
+    def traverse_files_and_perform_action(self) -> list[Any]:
+
+        """Derive all the paths to files in the desired directory.
+
+        Traverse them and call `perform_action_on_file` method of the FileAction instance
+        on each one of them
+
+        If there is any result different from None - append it to return list
+
+        :return: list, containing the return values (if such exist) of perform_action_on_file from each file
+        """
+
+        repo_of_results: list = []
+
+        all_fl_names_in_dir: list[str] = os.listdir(self._abs_path_to_dir)
+
+        fl_name_current: str  # File extension is included in the return value of os.listdir
+        for fl_name_current in all_fl_names_in_dir:
+
+            path_current: str = rf"{self._abs_path_to_dir}/{fl_name_current}"
+
+            res_from_action: Any | None = self._file_action.perform_action_on_file(
+                path_to_file=path_current
+            )
+
+            if res_from_action is not None:  # Append the result only if it is not None
+                repo_of_results.append(res_from_action)
+
+        return repo_of_results

--- a/file_workers/file_action.py
+++ b/file_workers/file_action.py
@@ -1,0 +1,24 @@
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class FileAction(ABC):
+
+    """
+    Abstract Base Class, providing a reliable blueprint method for working with files
+    """
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def perform_action_on_file(self, path_to_file: str, *args, **kwargs) -> Any | None:
+
+        """
+        :param path_to_file: str, (valid) abs path to a local file
+        :param args:
+        :param kwargs:
+        :return: Any or None -> up to the concrete implementation of a concrete child class
+        """
+
+        pass


### PR DESCRIPTION
- Added `FileAction` class, which defines the abstract method `perform_action_on_file` <br>
- Added `BaseFileTraverser` which receives an instance of a child class of `FileAction`, which has implemeted the `perform_action_on_file` method. The class calls the method on each file path, aggegates the results (if there are such) in a list, which is returned in the end. <br>
The goal of the current design is mainly for the `FileAction` class to be reusable outside the traversal.