### PR TITLE
Crawl technopolis listing pages

### DIFF
--- a/concrete_classes/technopolis/export_categories_for_crawl.py
+++ b/concrete_classes/technopolis/export_categories_for_crawl.py
@@ -1,0 +1,39 @@
+from concrete_classes.technopolis.techopolis_item_category import TechnopolisMainItemCategory, \
+    TechnopolisSubItemCategory
+
+
+def export_categories_for_crawl() -> list[TechnopolisSubItemCategory]:
+
+    """
+    Export a list of `TechnopolisSubItemCategory` pre-configured instances to be crawled
+    """
+
+    # TODO think about some more efficient way
+
+    categories_to_crawl: list[TechnopolisSubItemCategory] = []
+
+    # TV
+    _tv_main_cateogry: TechnopolisMainItemCategory = TechnopolisMainItemCategory(
+        category_name='TV--Video-i-Gaming',
+        category_number='P1109',
+    )
+    __tv_subcategory: TechnopolisSubItemCategory = TechnopolisSubItemCategory(
+        category_name='Televizori',
+        category_number='P11090104',
+        parent=_tv_main_cateogry
+    )
+    categories_to_crawl.append(__tv_subcategory)
+    __soundbar_subcategory: TechnopolisSubItemCategory = TechnopolisSubItemCategory(
+        category_name='Soundbar-sistemi',
+        category_number='P11090503',
+        parent=_tv_main_cateogry
+    )
+    categories_to_crawl.append(__soundbar_subcategory)
+    __bluray_dvd__subcategory: TechnopolisSubItemCategory = TechnopolisSubItemCategory(
+        category_name='Blu-Ray-i-DVD-pleari',
+        category_number='P11090301',
+        parent=_tv_main_cateogry,
+    )
+    categories_to_crawl.append(__bluray_dvd__subcategory)
+
+    return categories_to_crawl

--- a/concrete_classes/technopolis/techopolis_item_category.py
+++ b/concrete_classes/technopolis/techopolis_item_category.py
@@ -1,0 +1,61 @@
+
+
+class TechnopolisMainItemCategory:
+
+    """
+    Class representing a main category in the Technopolis website, e.g. TV, Audio and Gaming
+    """
+
+    def __init__(self, category_name: str, category_number: str):
+
+        self.__category_name: str = category_name
+        self.__category_number = category_number
+
+    @property
+    def category_name(self) -> str:
+        """
+        :return: str, tne string name as it is in the website
+        """
+        return self.__category_name
+
+    @property
+    def category_number(self) -> str:
+        """
+        :return: str, the specific, associated string for the specific category as it is in the website for the
+        """
+        return self.__category_number
+
+
+class TechnopolisSubItemCategory:
+
+    """
+    Class representing a Technopolis Subcategory, e.g. TVs
+    """
+
+    def __init__(self, category_name: str, category_number: str,
+                 parent: TechnopolisMainItemCategory):
+
+        self.__category_name: str = category_name
+        self.__category_number = category_number
+        self.__parent: TechnopolisMainItemCategory = parent
+
+    @property
+    def category_name(self) -> str:
+        """
+        :return: str, tne string name as it is in the website
+        """
+        return self.__category_name
+
+    @property
+    def category_number(self) -> str:
+        """
+        :return: str, the specific, associated string for the specific category as it is in the website for the
+        """
+        return self.__category_number
+
+    @property
+    def parent(self) -> TechnopolisMainItemCategory:
+        """
+        :return: instance of TechnopolisMainItemCategory representing the parent of the Subcategory
+        """
+        return self.__parent

--- a/concrete_classes/technopolis/techopolis_listing_page_crawler.py
+++ b/concrete_classes/technopolis/techopolis_listing_page_crawler.py
@@ -1,0 +1,123 @@
+import random
+import time
+
+import selenium.webdriver
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import NoSuchElementException
+
+from concrete_classes.technopolis.techopolis_item_category import TechnopolisSubItemCategory
+from selenium_classes.base_selenium_webdriver_setuper import BaseSeleniumWebdriverSetuper
+from selenium_classes.page_saver_selenium import PageSaverSelenium
+
+
+class TechnopolisListingPageCrawler:
+
+    """
+    Class for crawling the Technopolis listing pages for a specific subcategory
+    """
+
+    __MAIN_URL_FRAGMENT: str = "https://www.technopolis.bg/bg/"
+
+    def __init__(self, path_to_save_dir: str, technopolis_sub_category: TechnopolisSubItemCategory):
+
+        """
+
+        :param path_to_save_dir: str, (valid) abs path to the local file save dir
+        :param technopolis_sub_category: instance of TechnopolisSubItemCategory, used to specify the exact crawl
+        """
+
+        self._subcategory: TechnopolisSubItemCategory = technopolis_sub_category
+        self._path_to_save_dir: str = path_to_save_dir
+
+        self._base_selenium_webdriver_setuper: BaseSeleniumWebdriverSetuper = BaseSeleniumWebdriverSetuper()
+        self._page_saver: PageSaverSelenium = PageSaverSelenium()
+
+        self._main_driver: selenium.webdriver.Chrome = self._base_selenium_webdriver_setuper.get_base_pycharm_chrome_driver()
+
+    def crawl_pages_till_last(self) -> None:
+
+        """Crawl the instance's subcategory listing pages until the last page is reached.
+        Save the HTMLs in the instance's directory
+        """
+
+        current_page: int = 0  # the first page when the URLs are build like that is actually 0
+        while True:
+
+            url_current: str = self.__generate_url(page_number=current_page)
+            self._main_driver.get(url_current)
+            time.sleep(random.uniform(5, 9))
+            print(f"-- Current page is: {current_page}")
+
+            if current_page == 0:
+                self._accept_cookies()
+                time.sleep(random.uniform(3, 5))
+                print(f"-- Cookies accepted!")
+
+            fl_save_name_current: str = self._get_file_save_name(current_page=current_page)
+            abs_path: str = rf"{self._path_to_save_dir}/{fl_save_name_current}.html"
+            self._page_saver.save_page_source_as_html(
+                page_source=self._main_driver.page_source,
+                abs_path_for_file_saving=abs_path,
+            )
+
+            is_there_next_page: bool = self._is_next_page_button_present()
+
+            if not is_there_next_page:
+                break
+
+            current_page += 1
+
+        print(f"{self.__class__.__name__} finished crawling - quitting driver!")
+        self._main_driver.quit()
+
+    def _accept_cookies(self) -> None:
+
+        """Get the `Accept All Cookies` button by ID and click it.
+        """
+
+        accept_all_cookies_button = self._main_driver.find_element(
+            By.ID, "CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll"
+        )
+        accept_all_cookies_button.click()
+
+    def _is_next_page_button_present(self) -> bool:
+
+        """Check if there is a clickable next page button, to determine whether to continue the crawl
+        """
+
+        try:
+            next_page_button = self._main_driver.find_element(By.CLASS_NAME, "next")
+
+            if "disabled" in next_page_button.get_attribute("class"):
+                # In bigger categories, in the last page, the button is disabled. Check it in the class name
+                print("Next Page Button is Disabled!!!")
+                return False
+
+            print("Next page button found!")
+            return True
+        except NoSuchElementException:  # If there is just one page for a smaller category - button does not exist
+            print("There is no next page button! Stopping the crawl!")
+            return False
+
+    def _get_file_save_name(self, current_page: int) -> str:
+
+        """
+        """
+
+        fl_save_name: str = f"techonopolis-listing-page-{self._subcategory.category_name}-page-{str(current_page)}"
+        return fl_save_name
+
+    def __generate_url(self, page_number: int) -> str:
+
+        """Get the listing URL for the current sub-category depending on the given page
+        """
+
+        url: str = (f"{self.__MAIN_URL_FRAGMENT}"
+                    f"{self._subcategory.parent.category_name}/"
+                    f"{self._subcategory.category_name}"
+                    f"/c/"
+                    f"{self._subcategory.category_number}"
+                    f"?pageSize=90"  # In order to craw less pages, use the provided max number of items per page
+                    f"&currentPage={str(page_number)}")
+        return url
+        

--- a/scripts/technopolis/get_listing_pages.py
+++ b/scripts/technopolis/get_listing_pages.py
@@ -1,0 +1,34 @@
+from datetime import date
+import sys
+import os
+
+from concrete_classes.technopolis.export_categories_for_crawl import export_categories_for_crawl
+from concrete_classes.technopolis.techopolis_item_category import TechnopolisSubItemCategory
+from concrete_classes.technopolis.techopolis_listing_page_crawler import TechnopolisListingPageCrawler
+
+EXPORT_LIST: list[TechnopolisSubItemCategory] = export_categories_for_crawl()
+_PATH_TO_SAVE_DIR: str = r"/home/aleksandarm/Desktop/price_monitoring/price-monitoring/output/technopolis/"
+
+CURRENT_DATE: date = date.today()
+
+_TODAY_SAVE_DIR: str = rf"{_PATH_TO_SAVE_DIR}/{str(CURRENT_DATE)}"
+
+if not os.path.isdir(_TODAY_SAVE_DIR):
+    print("-- Creating save dir!")
+    os.makedirs(_TODAY_SAVE_DIR)
+else:
+    print("-- Save path already exists!")
+
+category_to_crawl: TechnopolisSubItemCategory
+for category_to_crawl in EXPORT_LIST:
+
+    print(f"{category_to_crawl.category_name} "
+          f"<> {category_to_crawl.category_number} "
+          f"<> {category_to_crawl.parent.category_name}")
+
+    current_crawler: TechnopolisListingPageCrawler = TechnopolisListingPageCrawler(
+        path_to_save_dir=_TODAY_SAVE_DIR,
+        technopolis_sub_category=category_to_crawl
+    )
+
+    current_crawler.crawl_pages_till_last()


### PR DESCRIPTION
Created a concrete class for crawling the listing pages for Technopolis. <br>
There are a lot of categories and subcategories to be crawled. I figured the best/quickest way was to create objects which represent how the URLs are structured for the specific categories. This requires a one-time manual creation of category objects. <br>
The listing crawler utulizes such object to build the specific URLs.